### PR TITLE
Validate commodity on update

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,10 @@ func updateCommodity(c *gin.Context) {
 
 	city := domain.Cities[name]
 
-	city.UpdateCommodity(commodity.Name, commodity.Buy, commodity.Sell, commodity.Production, commodity.Consumption)
+	if err := city.UpdateCommodity(commodity.Name, commodity.Buy, commodity.Sell, commodity.Production, commodity.Consumption); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	c.String(http.StatusOK, "updated!")
 }
@@ -84,7 +87,10 @@ func updateCommodities(c *gin.Context) {
 	city := domain.Cities[name]
 
 	for _, commodity := range commodities.Commodities {
-		city.UpdateCommodity(commodity.Name, commodity.Buy, commodity.Sell, commodity.Production, commodity.Consumption)
+		if err := city.UpdateCommodity(commodity.Name, commodity.Buy, commodity.Sell, commodity.Production, commodity.Consumption); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 	}
 
 	c.String(http.StatusOK, "updated!")

--- a/src/domain/city.go
+++ b/src/domain/city.go
@@ -1,5 +1,7 @@
 package domain
 
+import "fmt"
+
 // City The city
 type City struct {
 	Entity
@@ -11,14 +13,19 @@ func (c *City) getDistances() map[string]float32 {
 	return Distances[c.Name]
 }
 
-func (c *City) UpdateCommodity(name string, buy, sell, production, consumption int16) {
+func (c *City) UpdateCommodity(name string, buy, sell, production, consumption int16) error {
 	commodities := c.MarketHall.Commodities
-	commodity := commodities[name]
+	commodity, ok := commodities[name]
+	if !ok {
+		return fmt.Errorf("commodity %s not found", name)
+	}
 
 	commodity.Buy = buy
 	commodity.Sell = sell
 	commodity.Production = production
 	commodity.Consumption = consumption
+
+	return nil
 }
 
 func (c *City) GetCommodities() map[string]*Commodity {
@@ -69,7 +76,7 @@ func (c *City) GetStockCommodities() map[string]int16 {
 	return stocks
 }
 
-//Cities The Cities default
+// Cities The Cities default
 var Cities = map[string]*City{
 	"Edimburgo":   {Name: "Edimburgo"},
 	"Scarborough": {Name: "Scarborough"},

--- a/src/domain/city_test.go
+++ b/src/domain/city_test.go
@@ -16,11 +16,13 @@ func TestSupplyCommodity(t *testing.T) {
 
 	city := domain.Cities["Estocolmo"]
 
-	city.UpdateCommodity("Beer", 15, 16, 10, 100)
+	err := city.UpdateCommodity("Beer", 15, 16, 10, 100)
+	assert.NoError(t, err)
 	stock := city.GetSupplyCommodityFromCity("Beer", "Visby")
 	assert.Equal(t, int16(-30), stock)
 
-	city.UpdateCommodity("Beer", 16, 17, 11, 110)
+	err = city.UpdateCommodity("Beer", 16, 17, 11, 110)
+	assert.NoError(t, err)
 	stock = city.GetSupplyCommodityFromCity("Beer", "Visby")
 	assert.Equal(t, int16(-33), stock)
 
@@ -28,4 +30,16 @@ func TestSupplyCommodity(t *testing.T) {
 	assert.NotNil(t, city.MarketHall)
 	assert.NotNil(t, city.MarketHall.Commodities)
 	assert.Equal(t, 20, len(city.MarketHall.Commodities))
+}
+
+func TestUpdateCommodityNotFound(t *testing.T) {
+	for _, city := range domain.Cities {
+		commodities := domain.GetCommodities()
+		city.SetMarketHall(domain.MarketHall{Commodities: commodities})
+	}
+
+	city := domain.Cities["Estocolmo"]
+
+	err := city.UpdateCommodity("Unknown", 1, 1, 1, 1)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- validate commodity exists before updating
- handle errors in HTTP endpoints
- update city tests for new behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684edb790df08323bc081c4a85f81165