### PR TITLE
Add unit tests

### DIFF
--- a/src/application/use_cases/use_cases_test.go
+++ b/src/application/use_cases/use_cases_test.go
@@ -1,0 +1,47 @@
+package use_cases_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/adnvilla/patrician/src/application/use_cases"
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func prepareCities() {
+	for _, city := range domain.Cities {
+		commodities := domain.GetCommodities()
+		city.SetMarketHall(domain.MarketHall{Commodities: commodities})
+	}
+}
+
+func TestGetCitiesUseCase(t *testing.T) {
+	usecase := use_cases.NewGetCitiesUseCase()
+	result, err := usecase.Handle(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(domain.Cities), len(result))
+}
+
+func TestGetCityCommoditiesUseCase(t *testing.T) {
+	prepareCities()
+	usecase := use_cases.NewGetCityCommoditiesUseCase()
+	input := use_cases.GetCityCommoditiesInput{CityName: "Estocolmo"}
+	result, err := usecase.Handle(context.Background(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, len(domain.GetCommodities()), len(result))
+}
+
+func TestGetCommoditiesUseCase(t *testing.T) {
+	usecase := use_cases.NewGetCommoditiesUseCase()
+	result, err := usecase.Handle(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(domain.GetCommodities()), len(result))
+}
+
+func TestGetDistancesUseCase(t *testing.T) {
+	usecase := use_cases.NewGetDistancesUseCase()
+	result, err := usecase.Handle(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(domain.Distances), len(result))
+}

--- a/src/domain/city_additional_test.go
+++ b/src/domain/city_additional_test.go
@@ -1,0 +1,39 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func prepareCities() {
+	for _, city := range domain.Cities {
+		commodities := domain.GetCommodities()
+		city.SetMarketHall(domain.MarketHall{Commodities: commodities})
+	}
+}
+
+func TestGetStockCommodities(t *testing.T) {
+	prepareCities()
+	city := domain.Cities["Estocolmo"]
+
+	err := city.UpdateCommodity("Beer", 15, 16, 10, 100)
+	assert.NoError(t, err)
+
+	stocks := city.GetStockCommodities()
+	assert.Equal(t, 20, len(stocks))
+	assert.Equal(t, int16(-90), stocks["Beer"])
+}
+
+func TestGetSupplyCommoditiesFromCity(t *testing.T) {
+	prepareCities()
+	city := domain.Cities["Estocolmo"]
+
+	err := city.UpdateCommodity("Beer", 15, 16, 10, 100)
+	assert.NoError(t, err)
+
+	supply := city.GetSupplyCommoditiesFromCity("Visby")
+	assert.Equal(t, 20, len(supply))
+	assert.Equal(t, int16(-30), supply["Beer"])
+}

--- a/src/domain/commodity_additional_test.go
+++ b/src/domain/commodity_additional_test.go
@@ -1,0 +1,20 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommodityGetStock(t *testing.T) {
+	c := domain.Commodity{Production: 10, Consumption: 7}
+	assert.Equal(t, int16(3), c.GetStock())
+}
+
+func TestGetCommodities(t *testing.T) {
+	commodities := domain.GetCommodities()
+	assert.Equal(t, 20, len(commodities))
+	_, ok := commodities["Beer"]
+	assert.True(t, ok)
+}

--- a/src/domain/day_test.go
+++ b/src/domain/day_test.go
@@ -1,0 +1,13 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDayWeekConstants(t *testing.T) {
+	assert.Equal(t, float32(30), domain.Day)
+	assert.Equal(t, float32(210), domain.Week)
+}

--- a/src/interfaces/controllers/controllers_test.go
+++ b/src/interfaces/controllers/controllers_test.go
@@ -1,0 +1,82 @@
+package controllers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/adnvilla/patrician/src/interfaces/controllers"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func prepareCities() {
+	for _, city := range domain.Cities {
+		commodities := domain.GetCommodities()
+		city.SetMarketHall(domain.MarketHall{Commodities: commodities})
+	}
+}
+
+func setupRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/cities", controllers.GetCities)
+	r.GET("/commodities", controllers.GetCommodities)
+	r.GET("/distances", controllers.GetDistances)
+	r.GET("/city/:name/commodities", controllers.GetCityCommodities)
+	return r
+}
+
+func TestGetCitiesRoute(t *testing.T) {
+	prepareCities()
+	router := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodGet, "/cities", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resp)
+}
+
+func TestGetCommoditiesRoute(t *testing.T) {
+	prepareCities()
+	router := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodGet, "/commodities", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetDistancesRoute(t *testing.T) {
+	prepareCities()
+	router := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodGet, "/distances", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetCityCommoditiesRoute(t *testing.T) {
+	prepareCities()
+	router := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodGet, "/city/Estocolmo/commodities", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resp)
+}


### PR DESCRIPTION
## Summary
- add commodity and city tests
- add constants tests for Day and Week
- test use cases
- test controllers HTTP routes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ee8cdd1dc8323bee7cb32baa5e7be