### PR TITLE
Add integration tests with Postgres

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,17 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
     - uses: actions/checkout@v3
 
@@ -30,4 +41,6 @@ jobs:
       run: go build -v ./...
 
     - name: Test
+      env:
+        POSTGRES_DSN: "host=localhost user=postgres password=postgres dbname=postgres port=5432 sslmode=disable"
       run: go test -v ./...

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/adnvilla/patrician/src/infrastructure/data/postgresql"
+	"github.com/adnvilla/patrician/src/interfaces/handlers"
+	"github.com/gin-gonic/gin"
+)
+
+// setupRouter configures gin router with handlers.
+func setupRouter() *gin.Engine {
+	r := gin.Default()
+	r.GET("/cities", handlers.GetCities)
+	r.GET("/commodities", handlers.GetCommodities)
+	r.GET("/distances", handlers.GetDistances)
+	r.GET("/city/:name/commodities", handlers.GetCityCommodities)
+	return r
+}
+
+// prepareCities resets domain data before each test.
+func prepareCities() {
+	for _, city := range domain.Cities {
+		commodities := domain.GetCommodities()
+		city.SetMarketHall(domain.MarketHall{Commodities: commodities})
+	}
+}
+
+func setupDB(t *testing.T) {
+	db, err := postgresql.GetDB()
+	if err != nil {
+		t.Fatalf("failed to connect db: %v", err)
+	}
+	err = db.AutoMigrate(&postgresql.CityModel{}, &postgresql.MarketHallModel{}, &postgresql.CommodityModel{}, &postgresql.DistanceModel{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+}
+
+func TestCitiesEndpoint(t *testing.T) {
+	if os.Getenv("POSTGRES_DSN") == "" {
+		t.Skip("POSTGRES_DSN not set")
+	}
+	setupDB(t)
+	prepareCities()
+	router := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodGet, "/cities", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", w.Code)
+	}
+}

--- a/integration/repositories_test.go
+++ b/integration/repositories_test.go
@@ -1,0 +1,45 @@
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/adnvilla/patrician/src/domain"
+	"github.com/adnvilla/patrician/src/infrastructure/data/postgresql"
+)
+
+func setupPostgresDB(t *testing.T) {
+	db, err := postgresql.GetDB()
+	if err != nil {
+		t.Fatalf("connect db: %v", err)
+	}
+	err = db.AutoMigrate(&postgresql.CityModel{}, &postgresql.MarketHallModel{}, &postgresql.CommodityModel{}, &postgresql.DistanceModel{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+}
+
+func TestCityRepositoryPostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode")
+	}
+	if os.Getenv("POSTGRES_DSN") == "" {
+		t.Skip("POSTGRES_DSN not set")
+	}
+	setupPostgresDB(t)
+	db, _ := postgresql.GetDB()
+	repo := postgresql.NewCityRepository(db)
+
+	commodities := domain.GetCommodities()
+	mh := domain.MarketHall{Commodities: commodities}
+	city := domain.City{Name: "IntegrationCity", MarketHall: mh}
+
+	if err := repo.Create(&city); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	cities, err := repo.FindAll()
+	if err != nil || len(cities) == 0 {
+		t.Fatalf("findall: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add basic integration tests that require Postgres
- run Postgres service on GitHub Actions and set POSTGRES_DSN

## Testing
- `go test ./...`
- `go test ./integration -run TestCityRepositoryPostgres -v`

------
https://chatgpt.com/codex/tasks/task_e_684efa20e4d083238d3b2c78856b6411